### PR TITLE
Remove the setTimeout() + bindAll() hack

### DIFF
--- a/js/src/output.ts
+++ b/js/src/output.ts
@@ -103,7 +103,7 @@ class IPyWidgetOutput extends Shiny.OutputBinding {
           }
         })
       });
-    });
+    }); 
   }
 }
 


### PR DESCRIPTION
Closes #36 

To be merged after https://github.com/rstudio/py-shiny/pull/174