### PR TITLE
Don't supply new layout defaults (or fill) jupyter-widget-controls

### DIFF
--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -292,6 +292,10 @@ def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
     if not isinstance(widget, DOMWidget):
         return (widget, fill)
 
+    # Do nothing for "input-like" widgets (e.g., ipywidgets.IntSlider())
+    if getattr(widget, "_model_module", None) == "@jupyter-widgets/controls":
+        return (widget, False)
+
     layout = widget.layout         # type: ignore
 
     # Give the ipywidget Layout() width/height defaults that are more sensible for


### PR DESCRIPTION
This is a follow-up to #115, which set new layout defaults of `width:100%; height:400px`. Those new defaults are great for most output-like widgets, but not for input controls like [the ones shipped with ipywidgets](https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20List.html)