### PR TITLE
`render_widget` now attaches it's return value to the decorated function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+* The `@render_widget` decorator now attaches a `widget` (and `value`) attribute to the function it decorates. This allows for easier access to the widget instance (or value), and eliminates the need for `register_widget` (which is now soft deprecated).  (#119)
 * Reduce default plot margins on plotly graphs.
 
 ## [0.2.4] - 2023-11-20

--- a/examples/ipyleaflet/app.py
+++ b/examples/ipyleaflet/app.py
@@ -1,46 +1,50 @@
 import ipyleaflet as L
-from htmltools import css
-from shiny import *
+from shiny import App, reactive, render, req, ui
 
-from shinywidgets import output_widget, reactive_read, register_widget
+from shinywidgets import output_widget, reactive_read, render_widget
 
-app_ui = ui.page_fillable(
-    ui.div(
+app_ui = ui.page_sidebar(
+    ui.sidebar(
         ui.input_slider("zoom", "Map zoom level", value=4, min=1, max=10),
-        ui.output_text("map_bounds"),
-        style=css(
-            display="flex", justify_content="center", align_items="center", gap="2rem"
-        ),
     ),
-    output_widget("map"),
+    ui.card(
+        ui.output_text("map_bounds"),
+        fill=False
+    ),
+    ui.card(
+        output_widget("lmap")
+    ),
+    title="ipyleaflet demo"
 )
 
 
 def server(input, output, session):
 
-    # Initialize and display when the session starts (1)
-    map = L.Map(center=(52, 360), zoom=4)
-    register_widget("map", map)
+    @output
+    @render_widget
+    def lmap():
+        return L.Map(center=(52, 360), zoom=4)
 
     # When the slider changes, update the map's zoom attribute (2)
     @reactive.Effect
     def _():
-        map.zoom = input.zoom()
+        lmap.widget.zoom = input.zoom()
 
     # When zooming directly on the map, update the slider's value (2 and 3)
     @reactive.Effect
     def _():
-        ui.update_slider("zoom", value=reactive_read(map, "zoom"))
+        zoom = reactive_read(lmap.widget, "zoom")
+        ui.update_slider("zoom", value=zoom)
 
     # Everytime the map's bounds change, update the output message (3)
     @output
     @render.text
     def map_bounds():
-        b = reactive_read(map, "bounds")
+        b = reactive_read(lmap.widget, "bounds")
         req(b)
-        lat = [b[0][0], b[0][1]]
-        lon = [b[1][0], b[1][1]]
-        return f"The current latitude is {lat} and longitude is {lon}"
+        lat = [round(x) for x in [b[0][0], b[0][1]]]
+        lon = [round(x) for x in [b[1][0], b[1][1]]]
+        return f"The map bounds is currently {lat} / {lon}"
 
 
 app = App(app_ui, server)

--- a/examples/ipyleaflet/app.py
+++ b/examples/ipyleaflet/app.py
@@ -1,50 +1,36 @@
 import ipyleaflet as L
-from shiny import App, reactive, render, req, ui
+from shiny import reactive, render, req
+from shiny.express import input, ui
 
-from shinywidgets import output_widget, reactive_read, render_widget
+from shinywidgets import reactive_read, render_widget
 
-app_ui = ui.page_sidebar(
-    ui.sidebar(
-        ui.input_slider("zoom", "Map zoom level", value=4, min=1, max=10),
-    ),
-    ui.card(
-        ui.output_text("map_bounds"),
-        fill=False
-    ),
-    ui.card(
-        output_widget("lmap")
-    ),
-    title="ipyleaflet demo"
-)
+ui.page_opts(title="ipyleaflet demo")
+
+with ui.sidebar():
+    ui.input_slider("zoom", "Map zoom level", value=4, min=1, max=10)
+
+@render_widget
+def lmap():
+    return L.Map(center=(52, 360), zoom=4)
+
+# When the slider changes, update the map's zoom attribute
+@reactive.Effect
+def _():
+    lmap.widget.zoom = input.zoom()
+
+# When zooming directly on the map, update the slider's value
+@reactive.Effect
+def _():
+    zoom = reactive_read(lmap.widget, "zoom")
+    ui.update_slider("zoom", value=zoom)
 
 
-def server(input, output, session):
-
-    @output
-    @render_widget
-    def lmap():
-        return L.Map(center=(52, 360), zoom=4)
-
-    # When the slider changes, update the map's zoom attribute (2)
-    @reactive.Effect
-    def _():
-        lmap.widget.zoom = input.zoom()
-
-    # When zooming directly on the map, update the slider's value (2 and 3)
-    @reactive.Effect
-    def _():
-        zoom = reactive_read(lmap.widget, "zoom")
-        ui.update_slider("zoom", value=zoom)
-
-    # Everytime the map's bounds change, update the output message (3)
-    @output
-    @render.text
+with ui.card(fill=False):
+    # Everytime the map's bounds change, update the output message
+    @render.ui
     def map_bounds():
         b = reactive_read(lmap.widget, "bounds")
         req(b)
         lat = [round(x) for x in [b[0][0], b[0][1]]]
         lon = [round(x) for x in [b[1][0], b[1][1]]]
         return f"The map bounds is currently {lat} / {lon}"
-
-
-app = App(app_ui, server)

--- a/examples/ipywidgets/app.py
+++ b/examples/ipywidgets/app.py
@@ -1,35 +1,26 @@
-import ipywidgets as ipy
-from ipywidgets.widgets.widget import Widget
-from shiny import *
+import shiny.express
+from ipywidgets import IntSlider
+from shiny import render
 
-from shinywidgets import *
-
-app_ui = ui.page_fluid(output_widget("slider", fillable=False, fill=False), ui.output_text("slider_val"))
+from shinywidgets import reactive_read, render_widget
 
 
-def server(input: Inputs, output: Outputs, session: Session):
+@render_widget
+def slider():
+    return IntSlider(
+        value=7,
+        min=0,
+        max=10,
+        step=1,
+        description="Test:",
+        disabled=False,
+        continuous_update=False,
+        orientation="horizontal",
+        readout=True,
+        readout_format="d",
+    )
 
-    @output
-    @render_widget
-    def slider():
-        return ipy.IntSlider(
-            value=7,
-            min=0,
-            max=10,
-            step=1,
-            description="Test:",
-            disabled=False,
-            continuous_update=False,
-            orientation="horizontal",
-            readout=True,
-            readout_format="d",
-        )
-
-    @output
-    @render.text
-    def slider_val():
-        val = reactive_read(slider.widget, "value")
-        return f"The value of the slider is: {val}"
-
-
-app = App(app_ui, server, debug=True)
+@render.ui
+def slider_val():
+    val = reactive_read(slider.widget, "value")
+    return f"The value of the slider is: {val}"

--- a/examples/ipywidgets/app.py
+++ b/examples/ipywidgets/app.py
@@ -4,29 +4,32 @@ from shiny import *
 
 from shinywidgets import *
 
-app_ui = ui.page_fluid(output_widget("slider"), ui.output_text("value"))
+app_ui = ui.page_fluid(output_widget("slider", fillable=False, fill=False), ui.output_text("slider_val"))
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    s: Widget = ipy.IntSlider(
-        value=7,
-        min=0,
-        max=10,
-        step=1,
-        description="Test:",
-        disabled=False,
-        continuous_update=False,
-        orientation="horizontal",
-        readout=True,
-        readout_format="d",
-    )
 
-    register_widget("slider", s)
+    @output
+    @render_widget
+    def slider():
+        return ipy.IntSlider(
+            value=7,
+            min=0,
+            max=10,
+            step=1,
+            description="Test:",
+            disabled=False,
+            continuous_update=False,
+            orientation="horizontal",
+            readout=True,
+            readout_format="d",
+        )
 
-    @output(id="value")
+    @output
     @render.text
-    def _():
-        return f"The value of the slider is: {reactive_read(s, 'value')}"
+    def slider_val():
+        val = reactive_read(slider.widget, "value")
+        return f"The value of the slider is: {val}"
 
 
 app = App(app_ui, server, debug=True)

--- a/examples/plotly/app.py
+++ b/examples/plotly/app.py
@@ -1,9 +1,10 @@
 import numpy as np
 import plotly.graph_objs as go
-from shiny import *
+from shiny import reactive
+from shiny.express import input, ui
 from sklearn.linear_model import LinearRegression
 
-from shinywidgets import output_widget, render_widget
+from shinywidgets import render_plotly
 
 # Generate some data and fit a linear regression
 n = 10000
@@ -13,39 +14,31 @@ y = dat[1]
 fit = LinearRegression().fit(x.reshape(-1, 1), dat[1])
 xgrid = np.linspace(start=min(x), stop=max(x), num=30)
 
-app_ui = ui.page_fillable(
-    ui.input_checkbox("show_fit", "Show fitted line", value=True),
-    output_widget("scatterplot")
-)
+ui.page_opts(title="Plotly demo", fillable=True)
+
+ui.input_checkbox("show_fit", "Show fitted line", value=True)
+
+@render_plotly
+def scatterplot():
+    return go.FigureWidget(
+        data=[
+            go.Scattergl(
+                x=x,
+                y=y,
+                mode="markers",
+                marker=dict(color="rgba(0, 0, 0, 0.05)", size=5),
+            ),
+            go.Scattergl(
+                x=xgrid,
+                y=fit.intercept_ + fit.coef_[0] * xgrid,
+                mode="lines",
+                line=dict(color="red", width=2),
+            ),
+        ],
+        layout={"showlegend": False},
+    )
 
 
-def server(input, output, session):
-
-    @output
-    @render_widget
-    def scatterplot():
-        return go.FigureWidget(
-            data=[
-                go.Scattergl(
-                    x=x,
-                    y=y,
-                    mode="markers",
-                    marker=dict(color="rgba(0, 0, 0, 0.05)", size=5),
-                ),
-                go.Scattergl(
-                    x=xgrid,
-                    y=fit.intercept_ + fit.coef_[0] * xgrid,
-                    mode="lines",
-                    line=dict(color="red", width=2),
-                ),
-            ],
-            layout={"showlegend": False},
-        )
-
-    @reactive.Effect
-    def _():
-        scatterplot.widget.data[1].visible = input.show_fit()
-
-
-
-app = App(app_ui, server)
+@reactive.Effect
+def _():
+    scatterplot.widget.data[1].visible = input.show_fit()

--- a/examples/plotly/app.py
+++ b/examples/plotly/app.py
@@ -44,7 +44,7 @@ def server(input, output, session):
 
     @reactive.Effect
     def _():
-        plt.data[1].visible = input.show_fit()
+        scatterplot.widget.data[1].visible = input.show_fit()
 
 
 

--- a/examples/plotly/app.py
+++ b/examples/plotly/app.py
@@ -3,7 +3,7 @@ import plotly.graph_objs as go
 from shiny import *
 from sklearn.linear_model import LinearRegression
 
-from shinywidgets import output_widget, register_widget
+from shinywidgets import output_widget, render_widget
 
 # Generate some data and fit a linear regression
 n = 10000
@@ -15,35 +15,37 @@ xgrid = np.linspace(start=min(x), stop=max(x), num=30)
 
 app_ui = ui.page_fillable(
     ui.input_checkbox("show_fit", "Show fitted line", value=True),
-    output_widget("scatterplot"),
+    output_widget("scatterplot")
 )
 
 
 def server(input, output, session):
 
-    scatterplot = go.FigureWidget(
-        data=[
-            go.Scattergl(
-                x=x,
-                y=y,
-                mode="markers",
-                marker=dict(color="rgba(0, 0, 0, 0.05)", size=5),
-            ),
-            go.Scattergl(
-                x=xgrid,
-                y=fit.intercept_ + fit.coef_[0] * xgrid,
-                mode="lines",
-                line=dict(color="red", width=2),
-            ),
-        ],
-        layout={"showlegend": False},
-    )
-
-    register_widget("scatterplot", scatterplot)
+    @output
+    @render_widget
+    def scatterplot():
+        return go.FigureWidget(
+            data=[
+                go.Scattergl(
+                    x=x,
+                    y=y,
+                    mode="markers",
+                    marker=dict(color="rgba(0, 0, 0, 0.05)", size=5),
+                ),
+                go.Scattergl(
+                    x=xgrid,
+                    y=fit.intercept_ + fit.coef_[0] * xgrid,
+                    mode="lines",
+                    line=dict(color="red", width=2),
+                ),
+            ],
+            layout={"showlegend": False},
+        )
 
     @reactive.Effect
     def _():
-        scatterplot.data[1].visible = input.show_fit()
+        plt.data[1].visible = input.show_fit()
+
 
 
 app = App(app_ui, server)

--- a/examples/pydeck/app.py
+++ b/examples/pydeck/app.py
@@ -5,44 +5,45 @@ from shinywidgets import *
 
 app_ui = ui.page_fillable(
     ui.input_slider("zoom", "Zoom", 0, 20, 6, step=1),
-    output_widget("pydeck")
+    output_widget("deckmap")
 )
 
 def server(input: Inputs, output: Outputs, session: Session):
 
-    UK_ACCIDENTS_DATA = "https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
+    @output
+    @render_widget
+    def deckmap():
 
-    layer = pdk.Layer(
-        "HexagonLayer",  # `type` positional argument is here
-        UK_ACCIDENTS_DATA,
-        get_position=["lng", "lat"],
-        auto_highlight=True,
-        elevation_scale=50,
-        pickable=True,
-        elevation_range=[0, 3000],
-        extruded=True,
-        coverage=1,
-    )
+        UK_ACCIDENTS_DATA = "https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
 
-    view_state = pdk.ViewState(
-        longitude=-1.415,
-        latitude=52.2323,
-        zoom=6,
-        min_zoom=5,
-        max_zoom=15,
-        pitch=40.5,
-        bearing=-27.36,
-    )
+        layer = pdk.Layer(
+            "HexagonLayer",  # `type` positional argument is here
+            UK_ACCIDENTS_DATA,
+            get_position=["lng", "lat"],
+            auto_highlight=True,
+            elevation_scale=50,
+            pickable=True,
+            elevation_range=[0, 3000],
+            extruded=True,
+            coverage=1,
+        )
 
-    deck = pdk.Deck(layers=[layer], initial_view_state=view_state)
+        view_state = pdk.ViewState(
+            longitude=-1.415,
+            latitude=52.2323,
+            zoom=6,
+            min_zoom=5,
+            max_zoom=15,
+            pitch=40.5,
+            bearing=-27.36,
+        )
 
-    # Register either the deck (or deck_widget) instance
-    register_widget("pydeck", deck)
+        return pdk.Deck(layers=[layer], initial_view_state=view_state)
 
     @reactive.Effect()
     def _():
-        deck.initial_view_state.zoom = input.zoom()
-        deck.update()
+        deckmap.value.initial_view_state.zoom = input.zoom()
+        deckmap.value.update()
 
 
 app = App(app_ui, server)

--- a/examples/pydeck/app.py
+++ b/examples/pydeck/app.py
@@ -1,49 +1,37 @@
 import pydeck as pdk
-from shiny import *
+from shiny import reactive
+from shiny.express import input, ui
 
-from shinywidgets import *
+from shinywidgets import render_pydeck
 
-app_ui = ui.page_fillable(
-    ui.input_slider("zoom", "Zoom", 0, 20, 6, step=1),
-    output_widget("deckmap")
-)
+ui.input_slider("zoom", "Zoom", 0, 20, 6, step=1)
 
-def server(input: Inputs, output: Outputs, session: Session):
+@render_pydeck
+def deckmap():
+    UK_ACCIDENTS_DATA = "https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
+    layer = pdk.Layer(
+        "HexagonLayer",
+        UK_ACCIDENTS_DATA,
+        get_position=["lng", "lat"],
+        auto_highlight=True,
+        elevation_scale=50,
+        pickable=True,
+        elevation_range=[0, 3000],
+        extruded=True,
+        coverage=1,
+    )
+    view_state = pdk.ViewState(
+        longitude=-1.415,
+        latitude=52.2323,
+        zoom=6,
+        min_zoom=5,
+        max_zoom=15,
+        pitch=40.5,
+        bearing=-27.36,
+    )
+    return pdk.Deck(layers=[layer], initial_view_state=view_state)
 
-    @output
-    @render_widget
-    def deckmap():
-
-        UK_ACCIDENTS_DATA = "https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
-
-        layer = pdk.Layer(
-            "HexagonLayer",  # `type` positional argument is here
-            UK_ACCIDENTS_DATA,
-            get_position=["lng", "lat"],
-            auto_highlight=True,
-            elevation_scale=50,
-            pickable=True,
-            elevation_range=[0, 3000],
-            extruded=True,
-            coverage=1,
-        )
-
-        view_state = pdk.ViewState(
-            longitude=-1.415,
-            latitude=52.2323,
-            zoom=6,
-            min_zoom=5,
-            max_zoom=15,
-            pitch=40.5,
-            bearing=-27.36,
-        )
-
-        return pdk.Deck(layers=[layer], initial_view_state=view_state)
-
-    @reactive.Effect()
-    def _():
-        deckmap.value.initial_view_state.zoom = input.zoom()
-        deckmap.value.update()
-
-
-app = App(app_ui, server)
+@reactive.effect()
+def _():
+    deckmap.value.initial_view_state.zoom = input.zoom()
+    deckmap.value.update()

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,8 @@ setup_requires =
 install_requires =
     ipywidgets>=7.6.5
     jupyter_core
-    shiny>=0.5.1.9003
+    # shiny>=0.6.1.9003
+    shiny @ git+https://github.com/posit-dev/py-shiny.git
     python-dateutil>=2.8.2
     # Needed because of https://github.com/python/importlib_metadata/issues/411
     importlib-metadata>=4.8.3,<5; python_version < "3.8"

--- a/shinywidgets/__init__.py
+++ b/shinywidgets/__init__.py
@@ -10,7 +10,6 @@ from ._output_widget import output_widget
 from ._render_widget import (
     render_altair,
     render_bokeh,
-    render_leaflet,
     render_plotly,
     render_pydeck,
     render_widget,
@@ -22,7 +21,6 @@ __all__ = (
     "render_widget",
     "render_altair",
     "render_bokeh",
-    "render_leaflet",
     "render_plotly",
     "render_pydeck",
     # Reactive read second

--- a/shinywidgets/__init__.py
+++ b/shinywidgets/__init__.py
@@ -4,13 +4,34 @@ __author__ = """Carson Sievert"""
 __email__ = "carson@rstudio.com"
 __version__ = "0.2.4.9000"
 
+from ._as_widget import as_widget
 from ._dependencies import bokeh_dependency
-from ._shinywidgets import (
-    as_widget,
-    output_widget,
-    reactive_read,
-    register_widget,
+from ._output_widget import output_widget
+from ._render_widget import (
+    render_altair,
+    render_bokeh,
+    render_leaflet,
+    render_plotly,
+    render_pydeck,
     render_widget,
 )
+from ._shinywidgets import reactive_read, register_widget
 
-__all__ = ("output_widget", "register_widget", "render_widget", "reactive_read", "bokeh_dependency", "as_widget")
+__all__ = (
+    # Render methods first
+    "render_widget",
+    "render_altair",
+    "render_bokeh",
+    "render_leaflet",
+    "render_plotly",
+    "render_pydeck",
+    # Reactive read second
+    "reactive_read",
+    # UI methods third
+    "output_widget",
+    # Other methods last
+    "as_widget",
+    "bokeh_dependency",
+    # Soft deprecated
+    "register_widget",
+)

--- a/shinywidgets/_as_widget.py
+++ b/shinywidgets/_as_widget.py
@@ -35,7 +35,7 @@ def as_widget(x: object) -> Widget:
 
 def as_widget_altair(x: object) -> Optional[Widget]:
     try:
-        from altair import JupyterChart
+        from altair import JupyterChart  # pyright: ignore[reportMissingTypeStubs]
     except ImportError:
         raise RuntimeError(
             "Failed to import altair.JupyterChart (do you need to pip install -U altair?)"
@@ -55,9 +55,9 @@ def as_widget_bokeh(x: object) -> Optional[Widget]:
     # TODO: ideally we'd do this in set_layout_defaults() but doing
     # `BokehModel(x)._model.sizing_mode = "stretch_both"`
     # there, but that doesn't seem to work??
-    from bokeh.plotting import figure
+    from bokeh.plotting import figure  # pyright: ignore[reportMissingTypeStubs]
 
-    if isinstance(x, figure):
+    if isinstance(x, figure):  # type: ignore
         x.sizing_mode = "stretch_both"  # pyright: ignore[reportGeneralTypeIssues]
 
     return BokehModel(x)  # type: ignore
@@ -67,7 +67,7 @@ def as_widget_plotly(x: object) -> Optional[Widget]:
     # Don't need a try import here since this won't be called unless x is a plotly object
     import plotly.graph_objects as go  # pyright: ignore[reportMissingTypeStubs]
 
-    if not isinstance(x, go.Figure):
+    if not isinstance(x, go.Figure):  # type: ignore
         raise TypeError(
             f"Don't know how to coerce {x} into a plotly.graph_objects.FigureWidget object."
         )

--- a/shinywidgets/_as_widget.py
+++ b/shinywidgets/_as_widget.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ipywidgets.widgets.widget import Widget
+from ipywidgets.widgets.widget import Widget  # pyright: ignore[reportMissingTypeStubs]
 
 from ._dependencies import widget_pkg
 
@@ -46,7 +46,7 @@ def as_widget_altair(x: object) -> Optional[Widget]:
 
 def as_widget_bokeh(x: object) -> Optional[Widget]:
     try:
-        from jupyter_bokeh import BokehModel
+        from jupyter_bokeh import BokehModel  # pyright: ignore[reportMissingTypeStubs]
     except ImportError:
         raise ImportError(
             "Install the jupyter_bokeh package to use bokeh with shinywidgets."
@@ -56,15 +56,16 @@ def as_widget_bokeh(x: object) -> Optional[Widget]:
     # `BokehModel(x)._model.sizing_mode = "stretch_both"`
     # there, but that doesn't seem to work??
     from bokeh.plotting import figure
+
     if isinstance(x, figure):
-        x.sizing_mode = "stretch_both"
+        x.sizing_mode = "stretch_both"  # pyright: ignore[reportGeneralTypeIssues]
 
     return BokehModel(x)  # type: ignore
 
 
 def as_widget_plotly(x: object) -> Optional[Widget]:
     # Don't need a try import here since this won't be called unless x is a plotly object
-    import plotly.graph_objects as go
+    import plotly.graph_objects as go  # pyright: ignore[reportMissingTypeStubs]
 
     if not isinstance(x, go.Figure):
         raise TypeError(

--- a/shinywidgets/_cdn.py
+++ b/shinywidgets/_cdn.py
@@ -1,0 +1,17 @@
+import os
+
+all = (
+    "SHINYWIDGETS_CDN",
+    "SHINYWIDGETS_CDN_ONLY",
+    "SHINYWIDGETS_EXTENSION_WARNING",
+)
+
+# Make it easier to customize the CDN fallback (and make it CDN-only)
+# https://ipywidgets.readthedocs.io/en/7.6.3/embedding.html#python-interface
+# https://github.com/jupyter-widgets/ipywidgets/blob/6f6156c7/packages/html-manager/src/libembed-amd.ts#L6-L14
+SHINYWIDGETS_CDN = os.getenv("SHINYWIDGETS_CDN", "https://cdn.jsdelivr.net/npm/")
+SHINYWIDGETS_CDN_ONLY = os.getenv("SHINYWIDGETS_CDN_ONLY", "false").lower() == "true"
+# Should shinywidgets warn if unable to find a local path to a widget extension?
+SHINYWIDGETS_EXTENSION_WARNING = (
+    os.getenv("SHINYWIDGETS_EXTENSION_WARNING", "false").lower() == "true"
+)

--- a/shinywidgets/_output_widget.py
+++ b/shinywidgets/_output_widget.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from htmltools import Tag, css, head_content, tags
+from shiny.module import resolve_id
+from shiny.ui.css import as_css_unit
+from shiny.ui.fill import as_fill_item, as_fillable_container
+
+from ._cdn import SHINYWIDGETS_CDN, SHINYWIDGETS_CDN_ONLY
+from ._dependencies import libembed_dependency, output_binding_dependency
+
+__all__ = ("output_widget",)
+
+
+def output_widget(
+    id: str,
+    *,
+    width: Optional[str] = None,
+    height: Optional[str] = None,
+    fill: Optional[bool] = None,
+    fillable: Optional[bool] = None,
+) -> Tag:
+    id = resolve_id(id)
+    res = tags.div(
+        *libembed_dependency(),
+        output_binding_dependency(),
+        head_content(
+            tags.script(
+                data_jupyter_widgets_cdn=SHINYWIDGETS_CDN,
+                data_jupyter_widgets_cdn_only=SHINYWIDGETS_CDN_ONLY,
+            )
+        ),
+        id=id,
+        class_="shiny-ipywidget-output shiny-report-size shiny-report-theme",
+        style=css(
+            width=as_css_unit(width),
+            height=as_css_unit(height),
+        ),
+    )
+
+    if fill is None:
+        fill = height is None
+
+    if fill:
+        res = as_fill_item(res)
+
+    if fillable is None:
+        fillable = height is None
+
+    if fillable:
+        res = as_fillable_container(res)
+
+    return res

--- a/shinywidgets/_render_widget.py
+++ b/shinywidgets/_render_widget.py
@@ -2,18 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ipywidgets.widgets import Widget  # pyright: ignore[reportMissingTypeStubs]
-
 if TYPE_CHECKING:
-    from altair import JupyterChart
+    from altair import JupyterChart  # pyright: ignore[reportMissingTypeStubs]
     from jupyter_bokeh import BokehModel  # pyright: ignore[reportMissingTypeStubs]
     from plotly.graph_objects import (  # pyright: ignore[reportMissingTypeStubs]
         FigureWidget,
     )
     from pydeck.widget import DeckGLWidget  # pyright: ignore[reportMissingTypeStubs]
-
-    # Leaflet Widget class is the same as a Widget
-    # from ipyleaflet import Widget as LeafletWidget
+else:
+    JupyterChart = BokehModel = FigureWidget = DeckGLWidget = object
 
 from ._render_widget_base import ValueT, WidgetT, render_widget_base
 
@@ -21,31 +18,25 @@ __all__ = (
     "render_widget",
     "render_altair",
     "render_bokeh",
-    "render_leaflet",
     "render_plotly",
     "render_pydeck",
 )
 
-
-class render_widget(render_widget_base[ValueT, Widget]):
+# In the generic case, just relay whatever the user's return type is
+# since we're not doing any coercion
+class render_widget(render_widget_base[WidgetT, WidgetT]):
     ...
 
-
+# Package specific renderers that require coercion (via as_widget())
+# NOTE: the types on these classes should mirror what as_widget() does
 class render_altair(render_widget_base[ValueT, JupyterChart]):
     ...
-
 
 class render_bokeh(render_widget_base[ValueT, BokehModel]):
     ...
 
-
-class render_leaflet(render_widget_base[WidgetT, WidgetT]):
-    ...
-
-
 class render_plotly(render_widget_base[ValueT, FigureWidget]):
     ...
-
 
 class render_pydeck(render_widget_base[ValueT, DeckGLWidget]):
     ...

--- a/shinywidgets/_render_widget.py
+++ b/shinywidgets/_render_widget.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ipywidgets.widgets import Widget  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from altair import JupyterChart
+    from jupyter_bokeh import BokehModel  # pyright: ignore[reportMissingTypeStubs]
+    from plotly.graph_objects import (  # pyright: ignore[reportMissingTypeStubs]
+        FigureWidget,
+    )
+    from pydeck.widget import DeckGLWidget  # pyright: ignore[reportMissingTypeStubs]
+
+    # Leaflet Widget class is the same as a Widget
+    # from ipyleaflet import Widget as LeafletWidget
+
+from ._render_widget_base import ValueT, WidgetT, render_widget_base
+
+__all__ = (
+    "render_widget",
+    "render_altair",
+    "render_bokeh",
+    "render_leaflet",
+    "render_plotly",
+    "render_pydeck",
+)
+
+
+class render_widget(render_widget_base[ValueT, Widget]):
+    ...
+
+
+class render_altair(render_widget_base[ValueT, JupyterChart]):
+    ...
+
+
+class render_bokeh(render_widget_base[ValueT, BokehModel]):
+    ...
+
+
+class render_leaflet(render_widget_base[WidgetT, WidgetT]):
+    ...
+
+
+class render_plotly(render_widget_base[ValueT, FigureWidget]):
+    ...
+
+
+class render_pydeck(render_widget_base[ValueT, DeckGLWidget]):
+    ...

--- a/shinywidgets/_render_widget_base.py
+++ b/shinywidgets/_render_widget_base.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from typing import Any, Generic, Optional, Sequence, TypeVar, Union, cast
+
+from htmltools import Tag
+from ipywidgets.widgets import Widget  # pyright: ignore[reportMissingTypeStubs]
+from shiny import reactive, req
+from shiny.reactive import (
+    Calc_ as shiny_reactive_calc_class,  # pyright: ignore[reportPrivateImportUsage]
+)
+from shiny.reactive import value as shiny_reactive_value
+from shiny.reactive._core import Context, get_current_context
+from shiny.render.renderer import Jsonifiable, Renderer, ValueFn
+from traitlets import Unicode
+
+from ._as_widget import as_widget
+from ._output_widget import output_widget
+from ._shinywidgets import reactive_depend, reactive_read, set_layout_defaults
+
+__all__ = (
+    "render_widget_base",
+    "WidgetT",
+    "ValueT",
+)
+
+# --------------------------------------------------------------------------------------------
+# Implement @render_widget()
+# --------------------------------------------------------------------------------------------
+
+ValueT = TypeVar("ValueT", bound=object)
+"""
+The type of the value returned by the Shiny app render function
+"""
+WidgetT = TypeVar("WidgetT", bound=Widget)
+"""
+The type of the widget created from the renderer's ValueT
+"""
+
+
+class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
+    """ """
+
+    def default_ui(self, id: str) -> Tag:
+        return output_widget(
+            id,
+            width=self.width,
+            height=self.height,
+            fill=self.fill,
+            fillable=self.fillable,
+        )
+
+    def __init__(
+        self,
+        _fn: Optional[ValueFn[ValueT]] = None,
+        *,
+        width: Optional[str] = None,
+        height: Optional[str] = None,
+        fill: Optional[bool] = None,
+        fillable: Optional[bool] = None,
+    ):
+        super().__init__(_fn)
+        self.width: Optional[str] = width
+        self.height: Optional[str] = height
+        self.fill: Optional[bool] = fill
+        self.fillable: Optional[bool] = fillable
+
+        # self._value: ValueT | None = None  # TODO-barret; Not right type
+        # self._widget: WidgetT | None = None
+        self._contexts: set[Context] = set()
+
+        self._value: shiny_reactive_value[ValueT | None] = shiny_reactive_value(None)
+        self._widget: shiny_reactive_value[WidgetT | None] = shiny_reactive_value(None)
+
+    async def render(self) -> Jsonifiable | None:
+        value = await self.fn()
+
+        # Attach value/widget attributes to user func so they can be accessed (in other reactive contexts)
+        self._value.set(value)
+        self._widget.set(None)
+
+        if value is None:
+            return None
+
+        # Ensure we have a widget & smart layout defaults
+        widget = as_widget(value)
+        widget, fill = set_layout_defaults(widget)
+
+        self._widget.set(
+            # TODO-future; Remove cast call once `as_widget()` returns a WidgetT
+            cast(WidgetT, widget)
+        )
+
+        return {
+            "model_id": str(
+                cast(
+                    Unicode,
+                    widget.model_id,  # pyright: ignore[reportUnknownMemberType]
+                )
+            ),
+            "fill": fill,
+        }
+
+    # ########
+    # Enhancements
+    # ########
+
+    # TODO-barret; Turn these into reactives. We do not have reactive values in `py-shiny`, we shouldn't have them in `py-shinywidgets`
+    # TODO-barret; Add `.reactive_read()` and `.reactive_depend()` methods
+
+    def value(self) -> ValueT:
+        value = self._value()
+        req(value)
+
+        # Can only get here if value is not `None`
+        value = cast(ValueT, value)
+        return value
+
+    def widget(self) -> WidgetT:
+        widget = self._widget()
+        req(widget)
+
+        # Can only get here if widget is not `None`
+        widget = cast(WidgetT, widget)
+        return widget
+
+    # def value_trait(self, name: str) -> Any:
+    #     return reactive_read(self.value(), name)
+    def widget_trait(self, name: str) -> Any:
+        return reactive_read(self.widget(), name)
+
+    # ##########################################################################
+
+    # TODO-future; Should this method be supported? Can we have full typing support for the trait values?
+    # Note: Barret,Carson Jan 11-2024;
+    # This method is a very Shiny-like approach to making reactive values from
+    # ipywidgets. However, it would not support reaching into the widget with full
+    # typing. Instead, it is recommended that we keep `reactive_read(widget_like_obj,
+    # name)` that upgrades a (nested within widget) value to a resolved value that will
+    # invalidate the current context when the widget value is updated (by some other
+    # means).
+    #
+    # Since we know that `@render_altair` is built on `altair.JupyterChart`, we know
+    # that `jchart.widget()` will return an `JupyterChart` object. This object has full
+    # typing, such as `jchart.widget().selections` which is a JupyterChart `Selections`
+    # object. Then using the `reactive_read()` function, we can create a reactive value
+    # from the `Selections` object. This allows for users to reach into the widget as
+    # much as possible (with full typing) before using `reactive_read()`.
+    #
+    # Ex:
+    # ----------------------
+    # ```python
+    # @render_altair
+    # def jchart():
+    #    return some_altair_chart
+    #
+    # @render.text
+    # def selected_point():
+    #    # This is a reactive value that will invalidate the current context when the chart's selection changes
+    #    selected_point = reactive_read(jchart.widget().selections, "point")
+    #    return f"The selected point is: {selected_point()}"
+    # ```
+    # ----------------------
+    #
+    # Final realization:
+    # The method below (`_reactive_trait()`) does not support reaching into the widget
+    # result object. If the method was updated to support a nested key (str), typing
+    # would not be supported.
+    #
+    # Therefore, `reactive_read()` should be used until we can dynamically create
+    # classes that wrap a widget. (Barret: I am not hopeful that this will be possible
+    # or worth the effort. Ex: `jchart.traits.selections.point()` would be a reactive
+    # and fully typed.)
+    def _reactive_trait(
+        self,
+        names: Union[str, Sequence[str]],
+    ) -> shiny_reactive_calc_class[Any]:
+        """
+        Create a reactive value of a widget's top-level value that can be accessed by
+        name.
+
+        Ex:
+
+        ```python
+        slider_value = slider.reactive_trait("value")
+
+        @render.text
+        def slider_val():
+            return f"The value of the slider is: {slider_value()}"
+        ```
+        """
+
+        if in_reactive_context():
+            raise RuntimeError(
+                "Calling `reactive_trait()` within a reactive context is not supported."
+            )
+
+        reactive_trait: shiny_reactive_value[Any] = shiny_reactive_value(None)
+
+        names_was_str = isinstance(names, str)
+        if isinstance(names, str):
+            names = [names]
+
+        @reactive.effect
+        def _():
+            # Set the value to None incase the widget doesn't exist / have the trait
+            reactive_trait.set(None)
+
+            widget = self.widget()
+
+            for name in names:
+                if not widget.has_trait(  # pyright: ignore[reportUnknownMemberType]
+                    name
+                ):
+                    raise ValueError(
+                        f"The '{name}' attribute of {widget.__class__.__name__} is not a "
+                        "widget trait, and so it's not possible to reactively read it. "
+                        "For a list of widget traits, call `.widget().trait_names()`."
+                    )
+
+            # # From `Widget.observe()` docs:
+            # A callable that is called when a trait changes. Its
+            # signature should be ``handler(change)``, where ``change`` is a
+            # dictionary. The change dictionary at least holds a 'type' key.
+            # * ``type``: the type of notification.
+            # Other keys may be passed depending on the value of 'type'. In the
+            # case where type is 'change', we also have the following keys:
+            # * ``owner`` : the HasTraits instance
+            # * ``old`` : the old value of the modified trait attribute
+            # * ``new`` : the new value of the modified trait attribute
+            # * ``name`` : the name of the modified trait attribute.
+            def on_key_update(change: object):
+                if names_was_str:
+                    val = getattr(widget, names[0])
+                else:
+                    val = tuple(getattr(widget, name) for name in names)
+
+                reactive_trait.set(val)
+
+            # set value to the init widget value
+            on_key_update(None)
+
+            # Setup - onchange
+            # When widget attr changes, update the reactive value
+            widget.observe(  # pyright: ignore[reportUnknownMemberType]
+                on_key_update,
+                names,  # pyright: ignore[reportGeneralTypeIssues]
+                "change",
+            )
+
+            # Teardown - onchange
+            # When the widget object is created again, remove the old observer
+            def on_ctx_invalidate():
+                widget.unobserve(  # pyright: ignore[reportUnknownMemberType]
+                    on_key_update,
+                    names,  # pyright: ignore[reportGeneralTypeIssues]
+                    "change",
+                )
+
+            get_current_context().on_invalidate(on_ctx_invalidate)
+
+        # Return a calc object that can only be read from
+        @reactive.calc
+        def trait_calc():
+            return reactive_trait()
+
+        return trait_calc
+
+    # Note: Should be removed once `._reactive_trait()` is removed
+    def _reactive_read(self, names: Union[str, Sequence[str]]) -> Any:
+        """
+        Reactively read a Widget's trait(s)
+        """
+        self._reactive_depend(names)
+
+        widget = self.widget()
+
+        return reactive_read(widget, names)
+
+    # Note: Should be removed once `._reactive_trait()` is removed
+    def _reactive_depend(
+        self,
+        names: Union[str, Sequence[str]],
+        type: str = "change",
+    ) -> None:
+        """
+        Reactively depend upon a Widget's trait(s)
+        """
+        return reactive_depend(self.widget(), names, type)
+
+
+def in_reactive_context() -> bool:
+    try:
+        # Raises a `RuntimeError` if there is no current context
+        get_current_context()
+        return True
+    except RuntimeError:
+        return False

--- a/shinywidgets/_render_widget_base.py
+++ b/shinywidgets/_render_widget_base.py
@@ -59,10 +59,10 @@ class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
         fillable: Optional[bool] = None,
     ):
         super().__init__(_fn)
-        self.width: Optional[str] = width
-        self.height: Optional[str] = height
-        self.fill: Optional[bool] = fill
-        self.fillable: Optional[bool] = fillable
+        self.width = width
+        self.height = height
+        self.fill = fill
+        self.fillable = fillable
 
         # self._value: ValueT | None = None  # TODO-barret; Not right type
         # self._widget: WidgetT | None = None

--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import copy
-import importlib
 import json
 import os
-import tempfile
-import warnings
-from typing import Any, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Sequence, Union, cast
 from uuid import uuid4
 from weakref import WeakSet
 
@@ -28,7 +25,8 @@ from shiny.session import get_current_session, require_active_session
 from ._as_widget import as_widget
 from ._cdn import SHINYWIDGETS_CDN_ONLY, SHINYWIDGETS_EXTENSION_WARNING
 from ._comm import BufferType, ShinyComm, ShinyCommManager
-from ._dependencies import require_dependency, widget_pkg
+from ._dependencies import require_dependency
+from ._utils import is_instance_of_class, package_dir
 
 __all__ = (
     "register_widget",
@@ -149,9 +147,10 @@ COMM_MANAGER = ShinyCommManager()
 # Reactivity
 # --------------------------------------
 
-
-# TODO-barret; Make method on RenderWidget base
 def reactive_read(widget: Widget, names: Union[str, Sequence[str]]) -> Any:
+    """
+    Reactively read a widget trait
+    """
     reactive_depend(widget, names)
     if isinstance(names, str):
         return getattr(widget, names)
@@ -165,7 +164,7 @@ def reactive_depend(
     type: str = "change",
 ) -> None:
     """
-    Reactively read a Widget's trait(s)
+    Take a reactive dependency on a widget trait
     """
 
     try:
@@ -195,10 +194,12 @@ def reactive_depend(
     ctx.on_invalidate(_)
 
 
-# TODO-barret; Proposal: Remove `register_widget()` in favor of `@render_widget`
 def register_widget(
     id: str, widget: Widget, session: Optional[Session] = None
 ) -> Widget:
+    """
+    Deprecated. Use @render_widget instead.
+    """
     if session is None:
         session = require_active_session(session)
 
@@ -210,90 +211,6 @@ def register_widget(
         return w
 
     return w
-
-
-def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
-    # If we detect a user specified height on the widget, then don't
-    # do filling layout (akin to the behavior of output_widget(height=...))
-    fill = True
-
-    if not isinstance(widget, DOMWidget):
-        return (widget, fill)
-
-    # Do nothing for "input-like" widgets (e.g., ipywidgets.IntSlider())
-    if getattr(widget, "_model_module", None) == "@jupyter-widgets/controls":
-        return (widget, False)
-
-    layout = widget.layout  # type: ignore
-
-    # If the ipywidget Layout() height is set to something other than "auto", then
-    # don't do filling layout https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Layout.html
-    if isinstance(layout, Layout):
-        if layout.height is not None and layout.height != "auto":  # type: ignore
-            fill = False
-
-    pkg = widget_pkg(widget)
-
-    # Plotly provides it's own layout API (which isn't a subclass of ipywidgets.Layout)
-    if pkg == "plotly":
-        from plotly.graph_objs import Layout as PlotlyLayout  # pyright: ignore
-
-        if isinstance(layout, PlotlyLayout):
-            if layout.height is not None:  # pyright: ignore[reportUnknownMemberType]
-                fill = False
-            # Default margins are also way too big
-            layout.template.layout.margin = dict(  # pyright: ignore
-                l=16, t=32, r=16, b=16
-            )
-            # Unfortunately, plotly doesn't want to respect the top margin template,
-            # so change that 60px default to 32px
-            if layout.margin["t"] == 60:  # pyright: ignore
-                layout.margin["t"] = 32  # pyright: ignore
-
-    widget.layout = layout
-
-    # altair, confusingly, isn't setup to fill it's Layout() container by default. I
-    # can't imagine a situation where you'd actually want it to _not_ fill the parent
-    # container since it'll be contained within the Layout() container, which has a
-    # full-fledged sizing API.
-    if pkg == "altair":
-        import altair as alt
-
-        # Since as_widget() has already happened, we only need to handle JupyterChart
-        if isinstance(widget, alt.JupyterChart):
-            if isinstance(
-                widget.chart,  # pyright: ignore[reportUnknownMemberType]
-                alt.ConcatChart,
-            ):
-                # Throw warning to use ui.layout_column_wrap() instead
-                warnings.warn(
-                    "Consider using shiny.ui.layout_column_wrap() instead of alt.concat() "
-                    "for multi-column layout (the latter doesn't support filling layout)."
-                )
-            else:
-                widget.chart = widget.chart.properties(width="container", height="container")  # type: ignore
-
-    return (widget, fill)
-
-
-# similar to base::system.file()
-def package_dir(package: str) -> str:
-    with tempfile.TemporaryDirectory():
-        pkg_file = importlib.import_module(".", package=package).__file__
-        if pkg_file is None:
-            raise ImportError(f"Couldn't load package {package}")
-        return os.path.dirname(pkg_file)
-
-
-def is_instance_of_class(
-    x: object, class_name: str, module_name: Optional[str] = None
-) -> bool:
-    typ = type(x)
-    res = typ.__name__ == class_name
-    if module_name is None:
-        return res
-    else:
-        return res and typ.__module__ == module_name
 
 
 # It doesn't, at the moment, seem feasible to establish a comm with statically rendered widgets,

--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -303,10 +303,10 @@ class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
     def widget(self) -> WidgetT | None:
         return self._get_reactive_obj(self._widget)
 
-    @value.setter
-    def value(self, value: object):
+    @widget.setter
+    def widget(self, widget: object):
         raise RuntimeError(
-            "The `value` attribute of a @render_widget function is read only."
+            "The `widget` attribute of a @render_widget function is read only."
         )
 
     # ########

--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -1,99 +1,39 @@
 from __future__ import annotations
 
-__all__ = (
-    "output_widget",
-    "register_widget",
-    "render_widget",
-    "reactive_read",
-    "as_widget",
-)
 import copy
 import importlib
 import json
 import os
 import tempfile
 import warnings
-from typing import Any, Generic, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import Any, Optional, Sequence, Tuple, Union, cast
 from uuid import uuid4
 from weakref import WeakSet
 
-from htmltools import Tag, TagList, css, head_content, tags
-from ipywidgets._version import (
-    __protocol_version__,  # pyright: ignore[reportUnknownVariableType]
-)
-from ipywidgets.widgets import DOMWidget, Layout, Widget
-from ipywidgets.widgets.widget import (
-    _remove_buffers,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
-)
-from shiny import Session, reactive, req
+import ipywidgets  # pyright: ignore[reportMissingTypeStubs]
+
+from ._render_widget import render_widget
+
+__protocol_version__ = ipywidgets._version.__protocol_version__
+DOMWidget = ipywidgets.widgets.DOMWidget
+Layout = ipywidgets.widgets.Layout
+Widget = ipywidgets.widgets.Widget
+_remove_buffers = ipywidgets.widgets.widget._remove_buffers  # pyright: ignore
+from htmltools import TagList
+from shiny import Session, reactive
 from shiny.http_staticfiles import StaticFiles
-from shiny.module import resolve_id
-from shiny.reactive._core import Context, get_current_context
-from shiny.render.renderer import Jsonifiable, Renderer, ValueFn
+from shiny.reactive._core import get_current_context
 from shiny.session import get_current_session, require_active_session
-from shiny.ui.css import as_css_unit
-from shiny.ui.fill import as_fill_item, as_fillable_container
-from traitlets import Unicode
 
 from ._as_widget import as_widget
+from ._cdn import SHINYWIDGETS_CDN_ONLY, SHINYWIDGETS_EXTENSION_WARNING
 from ._comm import BufferType, ShinyComm, ShinyCommManager
-from ._dependencies import (
-    libembed_dependency,
-    output_binding_dependency,
-    require_dependency,
-    widget_pkg,
+from ._dependencies import require_dependency, widget_pkg
+
+__all__ = (
+    "register_widget",
+    "reactive_read",
 )
-
-# Make it easier to customize the CDN fallback (and make it CDN-only)
-# https://ipywidgets.readthedocs.io/en/7.6.3/embedding.html#python-interface
-# https://github.com/jupyter-widgets/ipywidgets/blob/6f6156c7/packages/html-manager/src/libembed-amd.ts#L6-L14
-SHINYWIDGETS_CDN = os.getenv("SHINYWIDGETS_CDN", "https://cdn.jsdelivr.net/npm/")
-SHINYWIDGETS_CDN_ONLY = os.getenv("SHINYWIDGETS_CDN_ONLY", "false").lower() == "true"
-# Should shinywidgets warn if unable to find a local path to a widget extension?
-SHINYWIDGETS_EXTENSION_WARNING = (
-    os.getenv("SHINYWIDGETS_EXTENSION_WARNING", "false").lower() == "true"
-)
-
-
-def output_widget(
-    id: str,
-    *,
-    width: Optional[str] = None,
-    height: Optional[str] = None,
-    fill: Optional[bool] = None,
-    fillable: Optional[bool] = None,
-) -> Tag:
-    id = resolve_id(id)
-    res = tags.div(
-        *libembed_dependency(),
-        output_binding_dependency(),
-        head_content(
-            tags.script(
-                data_jupyter_widgets_cdn=SHINYWIDGETS_CDN,
-                data_jupyter_widgets_cdn_only=SHINYWIDGETS_CDN_ONLY,
-            )
-        ),
-        id=id,
-        class_="shiny-ipywidget-output shiny-report-size shiny-report-theme",
-        style=css(
-            width=as_css_unit(width),
-            height=as_css_unit(height),
-        ),
-    )
-
-    if fill is None:
-        fill = height is None
-
-    if fill:
-        res = as_fill_item(res)
-
-    if fillable is None:
-        fillable = height is None
-
-    if fillable:
-        res = as_fillable_container(res)
-
-    return res
 
 
 # --------------------------------------------------------------------------------------------
@@ -110,7 +50,7 @@ def init_shiny_widget(w: Widget):
     # Break out of any module-specific session. Otherwise, input.shinywidgets_comm_send
     # will be some module-specific copy.
     while hasattr(session, "_parent"):
-        session = cast(Session, session._parent)
+        session = cast(Session, session._parent)  # pyright: ignore
 
     # Previous versions of ipywidgets (< 8.0.5) had
     #   `Widget.comm = Instance('ipykernel.comm.Comm')`
@@ -141,7 +81,7 @@ def init_shiny_widget(w: Widget):
 
     # Initialize the comm...this will also send the initial state of the widget
     w.comm = ShinyComm(
-        comm_id=w._model_id,
+        comm_id=w._model_id,  # pyright: ignore
         comm_manager=COMM_MANAGER,
         target_name="jupyter.widgets",
         data={"state": state, "buffer_paths": buffer_paths},
@@ -205,143 +145,9 @@ SESSIONS = WeakSet()  # type: ignore
 COMM_MANAGER = ShinyCommManager()
 
 
-# --------------------------------------------------------------------------------------------
-# Implement @render_widget()
-# --------------------------------------------------------------------------------------------
-
-ValueT = TypeVar("ValueT", bound=object)
-WidgetT = TypeVar("WidgetT", bound=Widget)
-T = TypeVar("T", bound=object)
-
-
-class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
-    def default_ui(self, id: str) -> Tag:
-        return output_widget(
-            id,
-            width=self.width,
-            height=self.height,
-            fill=self.fill,
-            fillable=self.fillable,
-        )
-
-    def __init__(
-        self,
-        _fn: Optional[ValueFn[ValueT]] = None,
-        *,
-        width: Optional[str] = None,
-        height: Optional[str] = None,
-        fill: Optional[bool] = None,
-        fillable: Optional[bool] = None,
-    ):
-        super().__init__(_fn)
-        self.width: Optional[str] = width
-        self.height: Optional[str] = height
-        self.fill: Optional[bool] = fill
-        self.fillable: Optional[bool] = fillable
-
-        self._value: ValueT | None = None  # TODO-barret; Not right type
-        self._widget: WidgetT | None = None
-        self._contexts: set[Context] = set()
-
-    async def render(self) -> Jsonifiable | None:
-        value = await self.fn()
-
-        # Attach value/widget attributes to user func so they can be accessed (in other reactive contexts)
-        self._value = value
-        self._widget = None
-
-        # Invalidate any reactive contexts that have read these attributes
-        self._invalidate_contexts()
-
-        if value is None:
-            return None
-
-        # Ensure we have a widget & smart layout defaults
-        widget = as_widget(value)
-        widget, fill = set_layout_defaults(widget)
-
-        self._widget = cast(WidgetT, widget)
-
-        return {
-            "model_id": str(
-                cast(
-                    Unicode,
-                    widget.model_id,  # pyright: ignore[reportUnknownMemberType]
-                )
-            ),
-            "fill": fill,
-        }
-
-    # ########
-    # Enhancements
-    # ########
-
-    # TODO-barret; Turn these into reactives. We do not have reactive values in `py-shiny`, we shouldn't have them in `py-shinywidgets`
-    # TODO-barret; Add `.reactive_read()` and `.reactive_depend()` methods
-
-    def _get_reactive_obj(self, x: T) -> T | None:
-        self._register_current_context()
-        if x is not None:
-            return x
-        # If `self._value` or `self._widget` is None, we're reading in a reactive context,
-        # other than the render context, throw a silent exception
-        if self._has_current_context():
-            req(False)
-        return None
-
-    @property
-    def value(self) -> ValueT | None:
-        return self._get_reactive_obj(self._value)
-
-    @value.setter
-    def value(self, value: object):
-        raise RuntimeError(
-            "The `value` attribute of a @render_widget function is read only."
-        )
-
-    @property
-    def widget(self) -> WidgetT | None:
-        return self._get_reactive_obj(self._widget)
-
-    @widget.setter
-    def widget(self, widget: object):
-        raise RuntimeError(
-            "The `widget` attribute of a @render_widget function is read only."
-        )
-
-    # ########
-    # Reactivity contexts
-    # ########
-    def _has_current_context(self) -> bool:
-        try:
-            get_current_context()
-            return True
-        except RuntimeError:
-            return False
-
-    # _contexts: set[Context]
-    def _invalidate_contexts(self) -> None:
-        for ctx in self._contexts:
-            ctx.invalidate()
-
-    # If the widget/value is read in a reactive context, then we'll need to invalidate
-    # that context when the widget's value changes
-    def _register_current_context(self) -> None:
-        if not self._has_current_context():
-            return
-        self._contexts.add(get_current_context())
-
-
-class render_widget(render_widget_base[ValueT, Widget]):
-    ...
-
-
-# TODO-future; Add support for plotly (and other packages)
-# # Working proof of concept for `@render_plotly`
-# import plotly.graph_objects as go
-# FigureT = TypeVar("FigureT", bound=go.Figure | go.FigureWidget)
-# class render_plotly(render_widget_base[FigureT, go.FigureWidget]):
-#     ...
+# --------------------------------------
+# Reactivity
+# --------------------------------------
 
 
 # TODO-barret; Make method on RenderWidget base
@@ -371,7 +177,7 @@ def reactive_depend(
         names = [names]
 
     for name in names:
-        if not widget.has_trait(name):
+        if not widget.has_trait(name):  # pyright: ignore[reportUnknownMemberType]
             raise ValueError(
                 f"The '{name}' attribute of {widget.__class__.__name__} is not a "
                 "widget trait, and so it's not possible to reactively read it. "
@@ -389,6 +195,7 @@ def reactive_depend(
     ctx.on_invalidate(_)
 
 
+# TODO-barret; Proposal: Remove `register_widget()` in favor of `@render_widget`
 def register_widget(
     id: str, widget: Widget, session: Optional[Session] = None
 ) -> Widget:
@@ -429,17 +236,19 @@ def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
 
     # Plotly provides it's own layout API (which isn't a subclass of ipywidgets.Layout)
     if pkg == "plotly":
-        from plotly.graph_objs import Layout as PlotlyLayout
+        from plotly.graph_objs import Layout as PlotlyLayout  # pyright: ignore
 
         if isinstance(layout, PlotlyLayout):
-            if layout.height is not None:
+            if layout.height is not None:  # pyright: ignore[reportUnknownMemberType]
                 fill = False
             # Default margins are also way too big
-            layout.template.layout.margin = dict(l=16, t=32, r=16, b=16)
+            layout.template.layout.margin = dict(  # pyright: ignore
+                l=16, t=32, r=16, b=16
+            )
             # Unfortunately, plotly doesn't want to respect the top margin template,
             # so change that 60px default to 32px
-            if layout.margin["t"] == 60:
-                layout.margin["t"] = 32
+            if layout.margin["t"] == 60:  # pyright: ignore
+                layout.margin["t"] = 32  # pyright: ignore
 
     widget.layout = layout
 
@@ -452,7 +261,10 @@ def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
 
         # Since as_widget() has already happened, we only need to handle JupyterChart
         if isinstance(widget, alt.JupyterChart):
-            if isinstance(widget.chart, alt.ConcatChart):
+            if isinstance(
+                widget.chart,  # pyright: ignore[reportUnknownMemberType]
+                alt.ConcatChart,
+            ):
                 # Throw warning to use ui.layout_column_wrap() instead
                 warnings.warn(
                     "Consider using shiny.ui.layout_column_wrap() instead of alt.concat() "

--- a/shinywidgets/_utils.py
+++ b/shinywidgets/_utils.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+import tempfile
+from typing import Optional
+
+# similar to base::system.file()
+def package_dir(package: str) -> str:
+    with tempfile.TemporaryDirectory():
+        pkg_file = importlib.import_module(".", package=package).__file__
+        if pkg_file is None:
+            raise ImportError(f"Couldn't load package {package}")
+        return os.path.dirname(pkg_file)
+
+
+def is_instance_of_class(
+    x: object, class_name: str, module_name: Optional[str] = None
+) -> bool:
+    typ = type(x)
+    res = typ.__name__ == class_name
+    if module_name is None:
+        return res
+    else:
+        return res and typ.__module__ == module_name


### PR DESCRIPTION
This PR helps solve the problem of needing a widget object in scope if you want to set/get attribute values, and thus, effectively eliminates any need for `register_widget()`

### TODO

- [x] When the decorated function re-renders, anyone would read the value should get invalidated.
- [x] Can we provide typing/autocomplete on `render_func.widget`/`render_func.value`? 
- [x] Deprecate `register_widget()`?
   * Should only do this if we can do typing properly
- [x] Update overview to reflect the new mental "proxy" model

### Example/testing app

```python
import ipyleaflet as ipyl
from shiny import reactive, render, ui
from shiny.express import input

from shinywidgets import reactive_read, render_widget

print("A")

@render.text
def center():
    print("@render.text")
    cntr = reactive_read(map.widget, 'center')
    return f"Current center: {cntr}"

print("B")

@render_widget
def map():
    print("@render_widget")
    return ipyl.Map(zoom=input.zoom(), center=(0, 0))

print("C")
print("Widget value:", map.widget)

ui.input_slider("zoom", "Zoom", min=1, max=7, value=2, step=0.5)
```