### PR TITLE
`reactive_read()` now throws more informative errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to shinywidgets will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+* `reactive_read()` now throws a more informative error when attempting to read non-existing or non-trait attributes. (#120)
+
 ## [0.2.3] - 2023-11-13
 
 * Widgets now `fill` inside of a `fillable` container by default. For examples, see the [ipyleaflet](https://github.com/posit-dev/py-shinywidgets/blob/main/examples/ipyleaflet/app.py), [plotly](https://github.com/posit-dev/py-shinywidgets/blob/main/examples/plotly/app.py), or other [output](https://github.com/posit-dev/py-shinywidgets/blob/main/examples/outputs/app.py) examples. If this intelligent filling isn't desirable, either provide a `height` or `fillable=False` on `output_widget()`. (#115)
-* `as_widget()` uses the new `altair.JupyterChart()` to coerce `altair.Chart()` into a `ipywidgets.widgets.Widget` instance. (#120)
+* `as_widget()` uses the new `altair.JupyterChart()` to coerce `altair.Chart()` into a `ipywidgets.widgets.Widget` instance. (#113)
 
 ## [0.2.2] - 2023-10-31
 

--- a/examples/altair/app.py
+++ b/examples/altair/app.py
@@ -1,0 +1,37 @@
+import altair as alt
+from shiny import App, render, ui
+from vega_datasets import data
+
+from shinywidgets import output_widget, reactive_read, register_widget
+
+source = data.cars()
+
+app_ui = ui.page_fluid(
+    ui.output_text_verbatim("selection"),
+    output_widget("chart")
+)
+
+def server(input, output, session):
+
+    # Replicate JupyterChart interactivity
+    # https://altair-viz.github.io/user_guide/jupyter_chart.html#point-selections
+    brush = alt.selection_point(name="point", encodings=["color"], bind="legend")
+    chart = alt.Chart(source).mark_point().encode(
+        x='Horsepower:Q',
+        y='Miles_per_Gallon:Q',
+        color=alt.condition(brush, 'Origin:N', alt.value('grey')),
+    ).add_params(brush)
+
+    jchart = alt.JupyterChart(chart)
+
+    # Display/register the chart in the app_ui
+    register_widget("chart", jchart)
+
+    # Reactive-ly read point selections
+    @output
+    @render.text
+    def selection():
+        pt = reactive_read(jchart.selections, "point")
+        return "Selected point: " + str(pt)
+
+app = App(app_ui, server)

--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -255,7 +255,21 @@ def reactive_depend(
     Reactively read a Widget's trait(s)
     """
 
-    ctx = reactive.get_current_context()  # pyright: ignore[reportPrivateImportUsage]
+    try:
+        ctx = reactive.get_current_context()  # pyright: ignore[reportPrivateImportUsage]
+    except RuntimeError:
+        raise RuntimeError("reactive_read() must be called within a reactive context")
+
+    if isinstance(names, str):
+        names = [names]
+
+    for name in names:
+        if not widget.has_trait(name):
+            raise ValueError(
+                f"The '{name}' attribute of {widget.__class__.__name__} is not a "
+                "widget trait, and so it's not possible to reactively read it. "
+                "For a list of widget traits, call `.trait_names()` on the widget."
+            )
 
     def invalidate(change: object):
         ctx.invalidate()


### PR DESCRIPTION
With this change, if you try to `reactive_read()` a non-existant or non-trait widget attribute, you'll get an informative error. For example:

```python
import ipyleaflet as L
from htmltools import css
from shiny import *

from shinywidgets import output_widget, reactive_read, register_widget

app_ui = ui.page_fluid(
    output_widget("map"),
    ui.output_text("foo"),
)

def server(input, output, session):

    map = L.Map(center=(52, 360), zoom=4)
    register_widget("map", map)

    @output
    @render.text
    def foo():
        reactive_read(map, "foo")


app = App(app_ui, server)
```

<img width="687" alt="Screenshot 2023-11-16 at 3 47 27 PM" src="https://github.com/posit-dev/py-shinywidgets/assets/1365941/689cb798-3210-44fb-beb2-9f582391da05">


Note that this'll also improve a situation like https://github.com/posit-dev/py-shinywidgets/issues/112, where `jcharts.selections` itself isn't a trait but does inherit from `traitlets.HasTraits`  
