### PR TITLE
Throw a more informative error when non-ipywidget compatible objects are passed to `as_widget()`

### DIFF
--- a/shinywidgets/_as_widget.py
+++ b/shinywidgets/_as_widget.py
@@ -19,7 +19,7 @@ def as_widget(x: object) -> Widget:
     if _as_widget is None:
         msg = f"Don't know how to coerce {x} into a ipywidget.Widget object."
         if callable(getattr(x, "_repr_html_", None)):
-            msg += " Instead of using shinywidgets to render this object, you can use shiny's @render.ui decorator "
+            msg += " Instead of using shinywidgets to render this object, try using shiny's @render.ui decorator "
             msg += " https://shiny.posit.co/py/api/ui.output_ui.html#shiny.ui.output_ui"
         raise TypeError(msg)
 

--- a/shinywidgets/_as_widget.py
+++ b/shinywidgets/_as_widget.py
@@ -17,7 +17,11 @@ def as_widget(x: object) -> Widget:
 
     _as_widget = AS_WIDGET_MAP.get(pkg, None)
     if _as_widget is None:
-        raise TypeError(f"Don't know how to coerce {x} into a ipywidget.Widget object.")
+        msg = f"Don't know how to coerce {x} into a ipywidget.Widget object."
+        if callable(getattr(x, "_repr_html_", None)):
+            msg += " Instead of using shinywidgets to render this object, you can use shiny's @render.ui decorator "
+            msg += " https://shiny.posit.co/py/api/ui.output_ui.html#shiny.ui.output_ui"
+        raise TypeError(msg)
 
     res = _as_widget(x)
 


### PR DESCRIPTION
Closes #117


### TODO

It'd probably be wise to require https://github.com/posit-dev/py-htmltools/pull/74  (and wait until it's released)