### PR TITLE
Remove `id` from `render_widget_base.auto_output_ui`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
 install_requires =
     ipywidgets>=7.6.5
     jupyter_core
-    shiny>=0.6.1.9004
+    shiny>=0.6.1.9005
     python-dateutil>=2.8.2
     # Needed because of https://github.com/python/importlib_metadata/issues/411
     importlib-metadata>=4.8.3,<5; python_version < "3.8"

--- a/shinywidgets/_render_widget_base.py
+++ b/shinywidgets/_render_widget_base.py
@@ -38,12 +38,13 @@ The type of the widget created from the renderer's ValueT
 """
 T = TypeVar("T", bound=object)
 
+
 class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
     """ """
 
-    def auto_output_ui(self, id: str) -> Tag:
+    def auto_output_ui(self) -> Tag:
         return output_widget(
-            id,
+            self.output_id,
             width=self.width,
             height=self.height,
             fill=self.fill,
@@ -201,7 +202,7 @@ def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
                 warnings.warn(
                     "Consider using shiny.ui.layout_column_wrap() instead of alt.concat() "
                     "for multi-column layout (the latter doesn't support filling layout).",
-                    stacklevel=2
+                    stacklevel=2,
                 )
             else:
                 UndefinedType = alt.utils.schemapi.UndefinedType  # type: ignore


### PR DESCRIPTION
Related: https://github.com/posit-dev/py-shiny/pull/1030