### PR TITLE
Adds Deploy to Connect Cloud buttons to READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ typings/
 Untitled*.ipynb
 
 rsconnect-python/
+
+# Deploy to Connect Cloud Button
+*/*/README_FILES/*
+*/*/README.html

--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,5 @@ Untitled*.ipynb
 rsconnect-python/
 
 # Deploy to Connect Cloud Button
-*/*/README_FILES/*
-*/*/README.html
+examples/*/README_FILES/*
+examples/*/README.html

--- a/examples/outputs/README.md
+++ b/examples/outputs/README.md
@@ -1,0 +1,3 @@
+## Outputs app
+
+[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Foutputs%2Fapp.py&pythonVersion=3.11)

--- a/examples/outputs/README.md
+++ b/examples/outputs/README.md
@@ -1,3 +1,3 @@
 ## Outputs app
 
-[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Foutputs%2Fapp.py&pythonVersion=3.11)
+<a href='https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Foutputs%2Fapp.py&pythonVersion=3.11'><img src='https://cdn.connect.posit.cloud/assets/deploy-to-connect-blue.svg' align="right" /></a>

--- a/examples/plotly/README.md
+++ b/examples/plotly/README.md
@@ -1,0 +1,3 @@
+## Plotly app
+
+[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fplotly%2Fapp.py&pythonVersion=3.11)

--- a/examples/plotly/README.md
+++ b/examples/plotly/README.md
@@ -1,3 +1,4 @@
 ## Plotly app
 
-[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fplotly%2Fapp.py&pythonVersion=3.11)
+<a href='https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fplotly%2Fapp.py&pythonVersion=3.11'><img src='https://cdn.connect.posit.cloud/assets/deploy-to-connect-blue.svg' align="right" /></a>
+

--- a/examples/plotly/requirements.txt
+++ b/examples/plotly/requirements.txt
@@ -4,3 +4,4 @@ ipywidgets
 numpy
 pandas
 plotly
+scikit-learn

--- a/examples/superzip/README.md
+++ b/examples/superzip/README.md
@@ -1,5 +1,7 @@
 ## Data
 
-[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fsuperzip%2Fapp.py&pythonVersion=3.11)
+<a href='https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fsuperzip%2Fapp.py&pythonVersion=3.11'><img src='https://cdn.connect.posit.cloud/assets/deploy-to-connect-blue.svg' align="right" /></a>
+
+
 
 The `superzip.csv` is the result of [this script](https://github.com/rstudio/shinycoreci-apps/blob/main/apps/063-superzip-example/global.R)

--- a/examples/superzip/README.md
+++ b/examples/superzip/README.md
@@ -1,3 +1,5 @@
 ## Data
 
+[![](https://docs.posit.co/connect-cloud/images/cc-deploy.svg)](https://connect.posit.cloud/publish?framework=shiny&sourceRepositoryURL=https%3A%2F%2Fgithub.com%2Fposit-dev%2Fpy-shinywidgets&sourceRef=main&sourceRefType=branch&primaryFile=examples%2Fsuperzip%2Fapp.py&pythonVersion=3.11)
+
 The `superzip.csv` is the result of [this script](https://github.com/rstudio/shinycoreci-apps/blob/main/apps/063-superzip-example/global.R)


### PR DESCRIPTION
This PR adds a button to the README of each example app that allows users to quickly deploy the app to Connect Cloud and see it in action—with one click of the button. The PR does not otherwise affect the code in the apps or the repository. 

The buttons look like this.

<img width="1088" alt="Screenshot 2024-09-26 at 1 11 34 PM" src="https://github.com/user-attachments/assets/00b7fb0a-8363-4c4e-a91d-60e11a1955af">

When I tested it, every app deployed within seconds.

**Why add Deploy to Connect Cloud buttons?**

[Connect Cloud](https://connect.posit.cloud/) is part of Posit's strategy to provide value to Python users. With Connect Cloud, users can very quickly deploy and maintain Shiny apps straight from their Github repository. We believe in Connect Cloud as a company and want to highlight it alongside our own assets.