### PR TITLE
Allow for the `model_id` property to still be accessed after the widget is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - 2025-01-23
 
 * Fixed an issue with plotly graphs sometimes not getting fully removed from the DOM. (#178)
+* Fixed an issue with ipyleaflet erroring out when attempting to read the `.model_id` property of a closed widget object. (#179)
 
 ## [0.4.2] - 2024-12-18
 

--- a/shinywidgets/_comm.py
+++ b/shinywidgets/_comm.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 from shiny._utils import run_coro_hybrid
@@ -196,3 +197,30 @@ class ShinyComm:
     def handle_close(self, msg: Dict[str, object]) -> None:
         if self._close_callback is not None:
             self._close_callback(msg)
+
+
+@dataclass
+class OrphanedShinyComm:
+    """
+    A 'mock' `ShinyComm`. It's only purpose is to allow one to get
+    the `model_id` (i.e., `comm_id`) of a widget after closing it.
+    """
+
+    comm_id: str
+
+    def send(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        pass
+
+    def close(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        pass
+
+    def on_msg(self, callback: MsgCallback) -> None:
+        pass


### PR DESCRIPTION
This problem was first discovered via https://github.com/posit-dev/py-shinywidgets/issues/174

Here is a small reprex of the problem.

```python
from ipyleaflet import Map, Marker
from shiny import reactive
import shiny.express

from shinywidgets import render_widget

map = Map(zoom=2)

@render_widget
def map_out():
    reactive.invalidate_later(1)
    marker = Marker(location=(0, 0))
    map.add(marker)
    return map
```

After the 1st invalidation, you'll get:

```python
AttributeError: 'NoneType' object has no attribute 'comm_id'
```

This happens because `.add()` reads of the `.model_id` property of every `Widget` instance (i.e., `Marker()`) that has ever been added to it. And, in recent versions of shinywidgets, we now `.close()` widgets when the reactive context they were initialized in get invalidated. When a widget gets closed, normally reading `.model_id` will result in error since that property reads `.comm.comm_id`, but `.comm` is `None`.

The workaround here is come up with a "mock" comm object that we add after close that allows for the `.model_id` property to still be read.