### PR TITLE
Add anywidget as a hard dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updates to accomodate the new plotly v6.0.0 release. (#182)
 * Fixed an issue with plotly graphs sometimes not getting fully removed from the DOM. (#178)
+* Added `anywidget` as a package dependency since it's needed now for `altair` and `plotly` (and installing this packages won't necessarily install `anywidget`). (#183)
 * Fixed an issue with ipyleaflet erroring out when attempting to read the `.model_id` property of a closed widget object. (#179)
 * Fixed an issue where altair charts would sometimes render to a 0 height after being shown, hidden, and then shown again. (#180)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     jupyter_core
     shiny>=0.6.1.9005
     python-dateutil>=2.8.2
+    anywidget
 tests_require =
     pytest>=3
 zip_safe = False


### PR DESCRIPTION
Important projects like `altair` and `plotly` now use `anywidget` to implement their 2-way Jupyter bindings, but don't make `anywidget` a hard requirement.

That means, if you want to use `altair` or `plotly` with `shinywidgets`, you need to additionally install `anywidget`.

Since `anywidget` is relatively low dependency, it seems worth adding as a dependency, so users don't need to remember the additional install