### PR TITLE
Properly cleanup when the Widget is initialized by an implicit `as_widget()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to shinywidgets will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+* Fixed an issue introduced by v0.6.0 where cleanup not happening when it should. (#195)
+
 ## [0.6.0] - 2025-05-19
 
 * Widgets initialized inside a `reactive.effect()` are no longer automatically removed when the effect invalidates. (#191)

--- a/shinywidgets/_render_widget_base.py
+++ b/shinywidgets/_render_widget_base.py
@@ -71,7 +71,10 @@ class render_widget_base(Renderer[ValueT], Generic[ValueT, WidgetT]):
 
     async def render(self) -> Jsonifiable | None:
         with WidgetRenderContext(self.output_id):
-            value = await self.fn()
+            return await self._render()
+
+    async def _render(self) -> Jsonifiable | None:
+        value = await self.fn()
 
         # Attach value/widget attributes to user func so they can be accessed (in other reactive contexts)
         self._value = value


### PR DESCRIPTION
#191 introduced a problem where, if the widget that is initialized by an internal `as_widget()` call, then it doesn't get cleaned up.

For a minimal reprex of the issue, notice how clicking the button will keep inserting new plots

```python
import plotly.express as px
from shiny.express import input, ui

from shinywidgets import render_plotly

ui.input_action_button("redraw", "Redraw")

@render_plotly
def plot():
    input.redraw()
    return px.histogram(
        px.data.tips(),
        x="total_bill",
    )
```