### PR TITLE
fix: Use render output's Context for widget cleanup instead of current Context

### DIFF
--- a/shinywidgets/_render_widget_base.py
+++ b/shinywidgets/_render_widget_base.py
@@ -227,25 +227,46 @@ def set_layout_defaults(widget: Widget) -> Tuple[Widget, bool]:
 
 class WidgetRenderContext:
     """
-    Let the session when a widget is currently being rendered.
+    Let the session know when a widget is currently being rendered.
 
     This is used to ensure that widget's that are initialized in a render_widget()
     context are cleaned up properly when that context is re-entered.
+
+    The render Context is captured at __enter__ time so that init_shiny_widget can
+    register cleanup callbacks on the correct Context, even if the widget is
+    constructed inside a reactive.isolate() block (which temporarily replaces the
+    current Context with a short-lived temporary one).
     """
     def __init__(self, output_id):
         self.session = require_active_session(None)
         self.output_id = output_id
         self._old_id = vars(self.session).get("__shinywidget_current_output_id")
+        self._old_ctx = vars(self.session).get("__shinywidget_render_context")
 
     def __enter__(self):
         vars(self.session)["__shinywidget_current_output_id"] = self.output_id
+        vars(self.session)["__shinywidget_render_context"] = get_current_context()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         vars(self.session)["__shinywidget_current_output_id"] = self._old_id
+        vars(self.session)["__shinywidget_render_context"] = self._old_ctx
         return False
 
     @staticmethod
     def is_rendering_widget(session):
         id = vars(session).get("__shinywidget_current_output_id")
         return id is not None
+
+    @staticmethod
+    def get_render_context(session) -> Context:
+        """
+        Get the reactive Context that was active when the render function started.
+
+        This returns the render output's Context rather than the current Context,
+        which may be a temporary isolate Context.
+        """
+        ctx = vars(session).get("__shinywidget_render_context")
+        if ctx is None:
+            raise RuntimeError("Not currently rendering a widget")
+        return ctx

--- a/shinywidgets/_shinywidgets.py
+++ b/shinywidgets/_shinywidgets.py
@@ -29,7 +29,7 @@ from ._as_widget import as_widget
 from ._cdn import SHINYWIDGETS_CDN_ONLY, SHINYWIDGETS_EXTENSION_WARNING
 from ._comm import BufferType, OrphanedShinyComm, ShinyComm, ShinyCommManager
 from ._dependencies import require_dependency
-from ._render_widget_base import WidgetRenderContext, has_current_context
+from ._render_widget_base import WidgetRenderContext
 from ._utils import package_dir
 
 __all__ = (
@@ -148,9 +148,12 @@ def init_shiny_widget(w: Widget):
         _open_shiny_comm.destroy()
 
     # If the widget initialized in a reactive _output_ context, then cleanup the widget
-    # when the context gets invalidated.
-    if has_current_context():
-        ctx = get_current_context()
+    # when the context gets invalidated. Use the render output's Context (captured by
+    # WidgetRenderContext) rather than the current Context, because the widget may be
+    # constructed inside a reactive.isolate() block whose temporary Context gets
+    # invalidated prematurely (e.g., when upstream reactive sources change).
+    if WidgetRenderContext.is_rendering_widget(session):
+        ctx = WidgetRenderContext.get_render_context(session)
 
         def on_close():
             with session_context(session):
@@ -165,8 +168,7 @@ def init_shiny_widget(w: Widget):
                 if id in WIDGET_INSTANCE_MAP:
                     del WIDGET_INSTANCE_MAP[id]
 
-        if WidgetRenderContext.is_rendering_widget(session):
-            ctx.on_invalidate(on_close)
+        ctx.on_invalidate(on_close)
 
     # Keep track of what session this widget belongs to (so we can close it when the
     # session ends)


### PR DESCRIPTION
## Summary

- Fixes widget cleanup registering on a temporary `reactive.isolate()` Context instead of the render output's Context, which caused premature `widget.close()` when upstream reactive sources invalidated
- `WidgetRenderContext` now captures the render Context at `__enter__` time and exposes it via `get_render_context()`
- `init_shiny_widget` uses the captured render Context for `on_close` registration instead of `get_current_context()`

## Root Cause

When a widget (e.g., `FigureWidget`) is constructed inside `reactive.isolate()`, `get_current_context()` returns the temporary isolate Context. When `reactive.poll` or any upstream reactive source fires, it invalidates this temporary Context, which triggers `on_close()` → `w.close()`, destroying the widget before the browser renders it.

## Test plan

- [ ] Verify `examples/model-score` in py-shiny renders both Plotly charts correctly with streaming updates
- [ ] Verify that widgets created outside `reactive.isolate()` still clean up properly on re-render
- [ ] Verify that widgets created inside `reactive.isolate()` are only cleaned up when the render output re-executes, not when the isolate Context is invalidated

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)