### PR TITLE
fix: preserve child widget comm ordering for ipyleaflet updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Hardened widget teardown for re-rendered views so replacing a widget no longer emits known cleanup noise like `Widget is not attached` or dead-comm sync errors. Added Playwright regression coverage for repeated rerenders across plotly, altair, bokeh, and ipyleaflet, and wired that suite into GitHub Actions on Python 3.12. (#223)
+* Fixed an issue where parent widget updates could arrive before newly introduced child widget models were opened client-side, causing one-interaction lag or dropped updates in cases like `ipyleaflet` marker insertion. (#225)
 
 ## [0.7.2] - 2026-04-09
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ test =
     plotly>=5.0.0
     altair
     bokeh
-    ipyleaflet
+    ipyleaflet>=0.20.0
 dev =
     black>=23.1.0
     flake8>=6.0.0

--- a/shinywidgets/_comm.py
+++ b/shinywidgets/_comm.py
@@ -171,11 +171,16 @@ class ShinyComm:
         # N.B., if messages are sent immediately, run_coro_sync() could fail with
         # 'async function yielded control; it did not finish in one iteration.'
         # if executed outside of a reactive context.
-        if msg_type == "shinywidgets_comm_close":
+        if msg_type in ("shinywidgets_comm_close", "shinywidgets_comm_msg"):
             # The primary way widgets are closed are when a new widget is rendered in
             # its place (see render_widget_base). By sending close on_flushed(), we
             # ensure to close the 'old' widget after the new one is created. (avoiding a
             # "flicker" of the old widget being removed before the new one is created)
+            #
+            # Mutation messages also need to wait until flush is complete so any child
+            # widgets introduced by the update have already sent their comm_open
+            # messages. Without that ordering, the browser can receive a parent update
+            # that references child models it does not know about yet.
             session.on_flushed(_send)
         else:
             session.on_flush(_send)

--- a/tests/playwright/ipyleaflet_marker_click/app.py
+++ b/tests/playwright/ipyleaflet_marker_click/app.py
@@ -1,0 +1,29 @@
+from ipyleaflet import Map, Marker
+from ipywidgets import Layout
+from shiny import App, ui
+from shinywidgets import output_widget, render_widget
+
+app_ui = ui.page_sidebar(
+    ui.sidebar("Sidebar content"),
+    output_widget("map"),
+)
+
+
+def server(input, output, session):
+    def handle_click(**kwargs):
+        if kwargs.get("type") == "click":
+            map.widget.add_layer(Marker(location=kwargs.get("coordinates")))
+
+    @render_widget
+    def map():
+        m = Map(
+            center=(51.174608, 3.865813),
+            zoom=9,
+            scroll_wheel_zoom=True,
+            layout=Layout(width="80%", height="90vh"),
+        )
+        m.on_interaction(handle_click)
+        return m
+
+
+app = App(app_ui, server)

--- a/tests/playwright/ipyleaflet_marker_click/test_ipyleaflet_marker_click.py
+++ b/tests/playwright/ipyleaflet_marker_click/test_ipyleaflet_marker_click.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import time
+
+from playwright.sync_api import Page, expect
+
+
+def test_ipyleaflet_marker_renders_on_first_click(page: Page, local_app) -> None:
+    errors: list[str] = []
+    page.on(
+        "console",
+        lambda msg: errors.append(msg.text) if msg.type == "error" else None,
+    )
+    page.on("pageerror", lambda err: errors.append(str(err)))
+
+    page.goto(local_app.url)
+    map_locator = page.locator(".leaflet-container")
+    map_locator.wait_for(timeout=30000)
+    time.sleep(1)
+
+    map_bounds = map_locator.bounding_box()
+    assert map_bounds is not None
+
+    page.mouse.click(
+        map_bounds["x"] + map_bounds["width"] / 2,
+        map_bounds["y"] + map_bounds["height"] / 2,
+    )
+
+    expect(page.locator(".leaflet-marker-icon")).to_have_count(1, timeout=5000)
+    assert not any("state_change" in err.lower() for err in errors)

--- a/tests/playwright/ipyleaflet_marker_click/test_ipyleaflet_marker_click.py
+++ b/tests/playwright/ipyleaflet_marker_click/test_ipyleaflet_marker_click.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 from playwright.sync_api import Page, expect
 
 
@@ -16,7 +14,14 @@ def test_ipyleaflet_marker_renders_on_first_click(page: Page, local_app) -> None
     page.goto(local_app.url)
     map_locator = page.locator(".leaflet-container")
     map_locator.wait_for(timeout=30000)
-    time.sleep(1)
+    page.wait_for_function(
+        """() =>
+        document
+            .querySelector(".leaflet-container")
+            ?.classList.contains("leaflet-touch-zoom")
+        """,
+        timeout=30000,
+    )
 
     map_bounds = map_locator.bounding_box()
     assert map_bounds is not None


### PR DESCRIPTION
## Summary
- delay `shinywidgets_comm_msg` until the reactive flush completes so child widget `comm_open` messages arrive before parent state updates that reference them
- add a Playwright regression based on the minimal `ipyleaflet` marker-click repro from #211
- add `ipyleaflet` to test dependencies for the new browser regression

## Why
The failing case is a parent widget update that introduces child widgets during the same flush. On current `main`, the browser can receive the parent `shinywidgets_comm_msg` before the child widget models exist client-side, which causes the first click marker update in `ipyleaflet` to be dropped and triggers the `state_change` error reported in #211.

This change keeps the client-side ordering consistent by sending mutation messages on `session.on_flushed(...)`, matching the point where newly created child widget comms have already been published.

## Additional context
During review, I checked this against Jupyter's comm model. In the reference Jupyter stack, `comm_open` creates the client-side comm/model first, and later `comm_msg` traffic assumes that comm already exists. JupyterLab's kernel connection also documents that kernel messages are handled in the order they are received, and that async handling pauses later message processing until the current handler completes. This change is therefore aligning Shiny's delivery timing with the ordering the Jupyter widget protocol already expects, rather than introducing a new assumption.

I also validated the issue outside the original `ipyleaflet` repro: on `main`, a parent widget update that introduces new child widget models can lag by one interaction in plain `ipywidgets` containers as well; with this change, those child models are available client-side before the parent mutation is applied.

Fixes #211
Related to #215

## Test Plan
- `PATH=/Users/cpsievert/github/py-shinywidgets/.venv/bin:$PATH python -m pytest -c tests/playwright/playwright-pytest.ini tests/playwright`
