### PR TITLE
test: add Playwright regression test for issue #221

### DIFF
--- a/tests/playwright/issue_221_isolate/app.py
+++ b/tests/playwright/issue_221_isolate/app.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import ipywidgets as widgets
+import plotly.graph_objects as go
+from shiny import App, reactive, ui
+from shinywidgets import output_widget, render_widget
+
+
+app_ui = ui.page_fluid(
+    ui.h4("plot_in"),
+    output_widget("plot_in"),
+    ui.h4("plot_out"),
+    output_widget("plot_out"),
+    ui.h4("slider_in"),
+    output_widget("slider_in"),
+    ui.h4("slider_out"),
+    output_widget("slider_out"),
+)
+
+
+def server(input, output, session):
+    tick = reactive.value(0)
+
+    @reactive.effect
+    def _ticker():
+        reactive.invalidate_later(1)
+        with reactive.isolate():
+            tick.set(tick.get() + 1)
+
+    def make_plot(val: int) -> go.FigureWidget:
+        return go.FigureWidget(data=[go.Scatter(x=[1, 2, 3], y=[1, val + 1, 3])])
+
+    @render_widget
+    def plot_in():
+        with reactive.isolate():
+            current = tick.get()
+            return make_plot(current)
+
+    @render_widget
+    def plot_out():
+        with reactive.isolate():
+            current = tick.get()
+        return make_plot(current)
+
+    @render_widget
+    def slider_in():
+        with reactive.isolate():
+            current = tick.get()
+            return widgets.IntSlider(value=current, min=0, max=10)
+
+    @render_widget
+    def slider_out():
+        with reactive.isolate():
+            current = tick.get()
+        return widgets.IntSlider(value=current, min=0, max=10)
+
+
+app = App(app_ui, server)

--- a/tests/playwright/issue_221_isolate/app.py
+++ b/tests/playwright/issue_221_isolate/app.py
@@ -5,7 +5,6 @@ import plotly.graph_objects as go
 from shiny import App, reactive, ui
 from shinywidgets import output_widget, render_widget
 
-
 app_ui = ui.page_fluid(
     ui.h4("plot_in"),
     output_widget("plot_in"),

--- a/tests/playwright/issue_221_isolate/test_issue_221_isolate.py
+++ b/tests/playwright/issue_221_isolate/test_issue_221_isolate.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import time
-
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 
 def test_widgets_render_inside_and_outside_isolate(page: Page, local_app) -> None:
@@ -13,13 +11,12 @@ def test_widgets_render_inside_and_outside_isolate(page: Page, local_app) -> Non
     )
     page.on("pageerror", lambda err: errors.append(str(err)))
 
-    page.goto(local_app.url, wait_until="networkidle")
+    page.goto(local_app.url)
     page.wait_for_selector("#plot_out .js-plotly-plot", timeout=30000)
     page.wait_for_selector("#slider_out .widget-slider", timeout=30000)
-    time.sleep(3.5)
 
-    assert page.locator("#plot_in .js-plotly-plot").count() == 1
-    assert page.locator("#plot_out .js-plotly-plot").count() == 1
-    assert page.locator("#slider_in .widget-slider").count() == 1
-    assert page.locator("#slider_out .widget-slider").count() == 1
+    expect(page.locator("#plot_in .js-plotly-plot")).to_have_count(1, timeout=30000)
+    expect(page.locator("#plot_out .js-plotly-plot")).to_have_count(1, timeout=30000)
+    expect(page.locator("#slider_in .widget-slider")).to_have_count(1, timeout=30000)
+    expect(page.locator("#slider_out .widget-slider")).to_have_count(1, timeout=30000)
     assert not any("no comm channel defined" in err.lower() for err in errors)

--- a/tests/playwright/issue_221_isolate/test_issue_221_isolate.py
+++ b/tests/playwright/issue_221_isolate/test_issue_221_isolate.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import time
+
+from playwright.sync_api import Page
+
+
+def test_widgets_render_inside_and_outside_isolate(page: Page, local_app) -> None:
+    errors: list[str] = []
+    page.on(
+        "console",
+        lambda msg: errors.append(msg.text) if msg.type == "error" else None,
+    )
+    page.on("pageerror", lambda err: errors.append(str(err)))
+
+    page.goto(local_app.url, wait_until="networkidle")
+    page.wait_for_selector("#plot_out .js-plotly-plot", timeout=30000)
+    page.wait_for_selector("#slider_out .widget-slider", timeout=30000)
+    time.sleep(3.5)
+
+    assert page.locator("#plot_in .js-plotly-plot").count() == 1
+    assert page.locator("#plot_out .js-plotly-plot").count() == 1
+    assert page.locator("#slider_in .widget-slider").count() == 1
+    assert page.locator("#slider_out .widget-slider").count() == 1
+    assert not any("no comm channel defined" in err.lower() for err in errors)


### PR DESCRIPTION
## Summary
- Migrates the orphaned `tests/apps/issue_221_isolate_app.py` and `tests/test_issue_221_isolate.py` into the standard Playwright test structure (`tests/playwright/issue_221_isolate/`)
- Rewrites the test to use the standard `local_app` + `page` fixtures instead of custom browser/fixture scaffolding
- Verifies that widgets created inside `reactive.isolate()` blocks render without "no comm channel defined" errors
- Removes the unused `tests/apps/` directory (contained only the orphaned app + stale `__pycache__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)